### PR TITLE
update tagbot and version

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -4,13 +4,30 @@ on:
     types:
       - created
   workflow_dispatch:
+    inputs:
+      lookback:
+        default: 3
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
 jobs:
   TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor ==
-      'JuliaTagBot'
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Edit the following line to reflect the actual name of the GitHub Secret containing your private key
           ssh: ${{ secrets.DOCUMENTER_KEY }}
+          # ssh: ${{ secrets.NAME_OF_MY_SSH_PRIVATE_KEY_SECRET }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Cclib"
 uuid = "6bf0c929-756b-4df7-ab0b-d621f7ebeba1"
 authors = ["cclib development team"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"


### PR DESCRIPTION
Updating tagbot configuration. 
It should not work yet - for it to work one needs to deploy SSH keys as per [here](https://github.com/marketplace/actions/julia-tagbot#ssh-deploy-keys).
Doing that requires access I don't have. Therefore, will register this version manually.